### PR TITLE
feat: add scenario creation and export workflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -48,6 +48,43 @@ body {
   color: #475569;
 }
 
+.scenario-panel__header {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.scenario-panel__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.scenario-panel__create {
+  align-self: flex-start;
+  border: none;
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #16a34a 0%, #4ade80 100%);
+  color: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(22, 163, 74, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.scenario-panel__create:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(22, 163, 74, 0.35);
+}
+
+.scenario-panel__create:disabled {
+  cursor: not-allowed;
+  background: rgba(148, 163, 184, 0.6);
+  box-shadow: none;
+}
+
 .scenario-list {
   list-style: none;
   margin: 0;
@@ -631,6 +668,27 @@ body {
 .workspace-run--running {
   background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
   box-shadow: none;
+}
+
+.workspace-export {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 10px;
+  padding: 9px 18px;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.05);
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.workspace-export:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.workspace-export:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .workspace-components ul {

--- a/src/components/ScenarioPanel.tsx
+++ b/src/components/ScenarioPanel.tsx
@@ -10,7 +10,7 @@ type ScenarioPanelProps = {
   runningScenarioId: string | null;
   onRunScenario: (scenarioId: string) => void;
   onOpenScenario: (scenarioId: string) => void;
-  isActionsReady: boolean;
+  onCreateScenario: () => void;
 };
 
 const ScenarioPanelComponent = ({
@@ -19,14 +19,23 @@ const ScenarioPanelComponent = ({
   runningScenarioId,
   onRunScenario,
   onOpenScenario,
-  isActionsReady,
+  onCreateScenario,
 }: ScenarioPanelProps) => (
   <section className="panel scenario-panel">
-    <header className="panel__header">
-      <h2>시나리오 보드</h2>
-      <span className="panel__meta">
-        NAV 플래그 케이스와 상태 유지 흐름을 빠르게 실행합니다.
-      </span>
+    <header className="panel__header scenario-panel__header">
+      <div className="scenario-panel__heading">
+        <h2>시나리오 보드</h2>
+        <span className="panel__meta">
+          NAV 플래그 케이스와 상태 유지 흐름을 빠르게 실행합니다.
+        </span>
+      </div>
+      <button
+        type="button"
+        className="scenario-panel__create"
+        onClick={onCreateScenario}
+      >
+        + 시나리오 추가
+      </button>
     </header>
     <ul className="scenario-list scenario-list--compact">
       {scenarios.map((scenario, index) => {

--- a/src/components/ScenarioWorkspace.tsx
+++ b/src/components/ScenarioWorkspace.tsx
@@ -488,6 +488,40 @@ const ScenarioWorkspace = ({
     });
   };
 
+  const handleDownloadScenario = useCallback(() => {
+    const exportedActivities = activities.map((activity) => ({
+      id: activity.id,
+      stageName: activity.stageName,
+      activityTitle: activity.title || activity.id,
+      elements: activity.elements,
+    }));
+
+    const entryActivityId = exportedActivities[0]?.id ?? "";
+
+    const scenarioJson = {
+      id: scenario.id,
+      title: scenarioTitle,
+      description: scenarioDescription,
+      flagLabel: scenario.flagLabel,
+      entry: {
+        activityId: entryActivityId,
+      },
+      activities: exportedActivities,
+    };
+
+    const blob = new Blob([JSON.stringify(scenarioJson, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${scenario.id}.json`;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, [activities, scenario.flagLabel, scenario.id, scenarioTitle, scenarioDescription]);
+
   return (
     <div className="workspace-shell">
       <aside className="workspace-sidebar">
@@ -578,6 +612,14 @@ const ScenarioWorkspace = ({
               disabled={!isActionsReady}
             >
               {isRunning ? "실행중" : "실행"}
+            </button>
+            <button
+              type="button"
+              className="workspace-export"
+              onClick={handleDownloadScenario}
+              disabled={activities.length === 0}
+            >
+              JSON 다운로드
             </button>
           </form>
         </header>


### PR DESCRIPTION
## Summary
- add a creation button to the scenario board with dedicated styling
- manage workspace state to open existing scenarios or freshly generated drafts
- allow scenarios to be exported as JSON directly from the workspace, including a new export action button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0fc71e3988326901fbc8177881578