### PR TITLE
Add labs performance stress testing screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,6 +84,40 @@ body {
   box-shadow: 0 12px 24px rgba(30, 64, 175, 0.25);
 }
 
+.activity__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.activity__field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.activity__field input {
+  border: 1px solid #94a3b8;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 1rem;
+  background: #ffffff;
+  color: #0f172a;
+}
+
+.activity__hint {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #64748b;
+}
+
+.activity__metrics {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .activity__list {
   margin: 0;
   padding-left: 20px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import "./App.css";
 import DetailActivity from "./activities/DetailActivity";
 import FeedActivity from "./activities/FeedActivity";
 import HomeActivity from "./activities/HomeActivity";
+import LabsPerformanceActivity from "./activities/LabsPerformanceActivity";
+import LabsPerformanceDetailActivity from "./activities/LabsPerformanceDetailActivity";
 import ProfileActivity from "./activities/ProfileActivity";
 import SettingsActivity from "./activities/SettingsActivity";
 import { NFXStack, type StackRouteConfig } from "./lib/NFXStack";
@@ -36,6 +38,18 @@ const stackRoutes: StackRouteConfig[] = [
     name: "Feed",
     activity: FeedActivity,
     route: "/feed",
+  },
+  {
+    name: "LabsPerformance",
+    activity: LabsPerformanceActivity,
+    route: "/labs/performance",
+  },
+  {
+    name: "LabsPerformanceDetail",
+    activity: LabsPerformanceDetailActivity,
+    route: {
+      path: "/labs/performance/:mode/:id",
+    },
   },
 ];
 

--- a/src/activities/HomeActivity.tsx
+++ b/src/activities/HomeActivity.tsx
@@ -64,6 +64,9 @@ const HomeActivity: ActivityComponentType<HomeActivityParams> = ({
             <button type="button" onClick={() => push('Settings', {})}>
               Push Settings screen
             </button>
+            <button type="button" onClick={() => push('LabsPerformance', {})}>
+              Open performance lab
+            </button>
           </div>
         </section>
 

--- a/src/activities/LabsPerformanceActivity.tsx
+++ b/src/activities/LabsPerformanceActivity.tsx
@@ -1,0 +1,199 @@
+import { AppScreen } from "@stackflow/plugin-basic-ui";
+import type { ActivityComponentType } from "@stackflow/react";
+import { useStack } from "@stackflow/react";
+import { useMemo, useState } from "react";
+
+import { useNavActions } from "../hooks/useNavActions";
+import {
+  clearCache,
+  evictCacheTo,
+  usePerfCacheEntries,
+  usePerfCacheSummary,
+} from "../labs/performance/perfCache";
+
+const clampSize = (value: number, fallback: number, max = 512) => {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.min(max, Math.floor(value)));
+};
+
+const formatMB = (value: number) => `${value.toFixed(2)} MB`;
+
+const generateRunId = () => {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const LabsPerformanceActivity: ActivityComponentType = () => {
+  const { push } = useNavActions();
+  const stack = useStack();
+  const cacheSummary = usePerfCacheSummary();
+  const cacheEntries = usePerfCacheEntries();
+
+  const [keepSize, setKeepSize] = useState(10);
+  const [cacheSize, setCacheSize] = useState(10);
+  const [evictLimit, setEvictLimit] = useState(80);
+
+  const stackNames = useMemo(
+    () => stack.activities.map((activity) => `${activity.name} (${activity.id})`),
+    [stack.activities],
+  );
+
+  return (
+    <AppScreen appBar={{ title: "Labs: Performance" }}>
+      <section className="activity__header">
+        <h1>Performance Stress Playground</h1>
+        <p>
+          Compare Stackflow memory strategies by stacking heavy pages. Keep the component mounted
+          or rely on a global cache and observe memory growth, GC pressure, and resume latency.
+        </p>
+      </section>
+
+      <div className="activity__content">
+        <section className="activity__card">
+          <h2>Current Stack</h2>
+          <p>
+            Activities on stack: <strong>{stack.activities.length}</strong>
+          </p>
+          <ul className="activity__list">
+            {stackNames.map((label) => (
+              <li key={label}>{label}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="activity__card">
+          <h2>Strategy A — Keep Components Mounted</h2>
+          <p>
+            Generates a large payload with <code>for</code> loops and stores it directly inside the
+            activity&apos;s local state. Data stays in memory until the activity is popped.
+          </p>
+          <div className="activity__form">
+            <label className="activity__field">
+              <span>Payload size per push (MB)</span>
+              <input
+                type="number"
+                min={1}
+                max={512}
+                step={1}
+                value={keepSize}
+                onChange={(event) =>
+                  setKeepSize(clampSize(Number(event.target.value), keepSize))
+                }
+              />
+            </label>
+          </div>
+          <div className="activity__actions">
+            <button
+              type="button"
+              onClick={() =>
+                push("LabsPerformanceDetail", {
+                  id: generateRunId(),
+                  mode: "keep",
+                  sizeMB: keepSize,
+                })
+              }
+            >
+              Push heavy detail (keep mounted)
+            </button>
+          </div>
+          <p className="activity__hint">
+            Push repeatedly without popping to observe how memory increases as the stack grows.
+          </p>
+        </section>
+
+        <section className="activity__card">
+          <h2>Strategy B — Cache Only</h2>
+          <p>
+            The activity generates data once, stores it in a global cache keyed by <code>activityId</code>,
+            then releases the component when popped. Use this to test cache reuse and eviction policies.
+          </p>
+          <div className="activity__form">
+            <label className="activity__field">
+              <span>Payload size per push (MB)</span>
+              <input
+                type="number"
+                min={1}
+                max={512}
+                step={1}
+                value={cacheSize}
+                onChange={(event) =>
+                  setCacheSize(clampSize(Number(event.target.value), cacheSize))
+                }
+              />
+            </label>
+            <label className="activity__field">
+              <span>Evict down to (MB)</span>
+              <input
+                type="number"
+                min={1}
+                max={1024}
+                step={1}
+                value={evictLimit}
+                onChange={(event) =>
+                  setEvictLimit(clampSize(Number(event.target.value), evictLimit, 1024))
+                }
+              />
+            </label>
+          </div>
+          <div className="activity__actions">
+            <button
+              type="button"
+              onClick={() =>
+                push("LabsPerformanceDetail", {
+                  id: generateRunId(),
+                  mode: "cache",
+                  sizeMB: cacheSize,
+                })
+              }
+            >
+              Push heavy detail (cache only)
+            </button>
+            <button type="button" onClick={() => evictCacheTo(evictLimit)}>
+              Evict to limit
+            </button>
+            <button type="button" onClick={() => clearCache()}>
+              Clear cache
+            </button>
+          </div>
+          <p className="activity__hint">
+            Pop the activity and push it again to measure resume latency when reading from the cache.
+          </p>
+          <div className="activity__metrics">
+            <p>
+              Cache usage: <strong>{formatMB(cacheSummary.totalMB)}</strong> across
+              <strong> {cacheSummary.entryCount}</strong> entries
+            </p>
+            <ul className="activity__list">
+              {cacheEntries.length === 0 && <li>No cached entries yet.</li>}
+              {cacheEntries.map((entry) => (
+                <li key={entry.activityId}>
+                  {entry.label} • {formatMB(entry.sizeMB)} • last accessed {" "}
+                  {new Date(entry.lastAccessed).toLocaleTimeString()}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="activity__card">
+          <h2>Measurement Tips</h2>
+          <ul className="activity__list">
+            <li>Android Chrome: open DevTools &rarr; Memory panel for rough heap usage.</li>
+            <li>Measure resume latency by counting the time between push/back and first paint.</li>
+            <li>
+              Keep an eye on FPS/Long Task overlays to understand GC pressure as cache size increases.
+            </li>
+          </ul>
+        </section>
+      </div>
+    </AppScreen>
+  );
+};
+
+export default LabsPerformanceActivity;

--- a/src/activities/LabsPerformanceDetailActivity.tsx
+++ b/src/activities/LabsPerformanceDetailActivity.tsx
@@ -1,0 +1,192 @@
+import { AppScreen } from "@stackflow/plugin-basic-ui";
+import type { ActivityComponentType } from "@stackflow/react";
+import { useActivity, useStack } from "@stackflow/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useNavActions } from "../hooks/useNavActions";
+import {
+  registerCacheEntry,
+  removeCacheEntry,
+  touchCacheEntry,
+  usePerfCacheEntry,
+} from "../labs/performance/perfCache";
+
+type Mode = "keep" | "cache";
+
+type LabsPerformanceDetailParams = {
+  id: string;
+  mode: Mode;
+  sizeMB?: number | string;
+};
+
+const clampSize = (value: number) => {
+  if (Number.isNaN(value) || !Number.isFinite(value)) {
+    return 10;
+  }
+
+  return Math.max(1, Math.min(512, Math.floor(value)));
+};
+
+const createPayload = (sizeMB: number) => {
+  const bytes = clampSize(sizeMB) * 1024 * 1024;
+  const buffer = new Uint8Array(bytes);
+  for (let index = 0; index < bytes; index += 1) {
+    buffer[index] = index % 256;
+  }
+  return buffer;
+};
+
+const formatBytes = (bytes: number) => {
+  if (bytes === 0) {
+    return "0 bytes";
+  }
+
+  const mb = bytes / (1024 * 1024);
+  return `${bytes.toLocaleString()} bytes (${mb.toFixed(2)} MB)`;
+};
+
+const LabsPerformanceDetailActivity: ActivityComponentType<LabsPerformanceDetailParams> = ({
+  params,
+}) => {
+  const activity = useActivity();
+  const activityId = activity.id;
+  const stack = useStack();
+  const { pop } = useNavActions();
+
+  const mode: Mode = params.mode === "cache" ? "cache" : "keep";
+  const sizeCandidate = typeof params.sizeMB === "string" ? Number(params.sizeMB) : params.sizeMB;
+  const sizeMB = clampSize(sizeCandidate ?? 10);
+  const label = useMemo(() => `detail-${params.id}`, [params.id]);
+
+  const cachedEntry = usePerfCacheEntry(activityId);
+  const touchedRef = useRef(false);
+  const allowBootstrapRef = useRef(true);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [localPayload, setLocalPayload] = useState<Uint8Array | null>(() =>
+    mode === "keep" ? createPayload(sizeMB) : null,
+  );
+
+  useEffect(() => {
+    if (mode !== "cache") {
+      return;
+    }
+
+    if (!cachedEntry) {
+      if (!allowBootstrapRef.current) {
+        return;
+      }
+
+      setIsGenerating(true);
+      const data = createPayload(sizeMB);
+      registerCacheEntry(activityId, label, data);
+      touchedRef.current = true;
+      setIsGenerating(false);
+      return;
+    }
+
+    if (!touchedRef.current) {
+      touchCacheEntry(activityId);
+      touchedRef.current = true;
+    }
+  }, [activityId, cachedEntry, label, mode, sizeMB]);
+
+  const payload = mode === "keep" ? localPayload : cachedEntry?.data ?? null;
+  const payloadPreview = useMemo(() => {
+    if (!payload) {
+      return "";
+    }
+
+    const sample = payload.slice(0, Math.min(24, payload.length));
+    return Array.from(sample).join(", ");
+  }, [payload]);
+
+  const rebuildPayload = () => {
+    if (mode === "keep") {
+      setLocalPayload(createPayload(sizeMB));
+      return;
+    }
+
+    const data = createPayload(sizeMB);
+    registerCacheEntry(activityId, label, data);
+    allowBootstrapRef.current = true;
+    touchedRef.current = true;
+  };
+
+  const removeFromCache = () => {
+    if (mode === "cache") {
+      removeCacheEntry(activityId);
+      allowBootstrapRef.current = false;
+      touchedRef.current = false;
+    }
+  };
+
+  return (
+    <AppScreen appBar={{ title: `Perf Detail (${mode})` }}>
+      <section className="activity__header">
+        <h1>Performance Detail</h1>
+        <p>
+          Activity <strong>{activityId}</strong> using <strong>{mode}</strong> strategy with target size
+          {" "}
+          <strong>{sizeMB} MB</strong>.
+        </p>
+      </section>
+
+      <div className="activity__content">
+        <section className="activity__card">
+          <h2>Payload Status</h2>
+          <p>Generation state: {isGenerating ? "building payload" : "idle"}</p>
+          <p>Allocated: <strong>{formatBytes(payload?.byteLength ?? 0)}</strong></p>
+          {payload && (
+            <pre className="activity__code">{payloadPreview}</pre>
+          )}
+          <div className="activity__actions">
+            <button type="button" onClick={() => pop()}>
+              Pop activity
+            </button>
+            <button type="button" onClick={rebuildPayload}>
+              Rebuild payload
+            </button>
+            {mode === "cache" && (
+              <button type="button" onClick={removeFromCache}>
+                Remove from cache
+              </button>
+            )}
+          </div>
+        </section>
+
+        <section className="activity__card">
+          <h2>Stack Snapshot</h2>
+          <p>
+            Stack depth: <strong>{stack.activities.length}</strong>
+          </p>
+          <ul className="activity__list">
+            {stack.activities.map((item) => (
+              <li key={item.id}>
+                {item.name} — {item.id}
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {mode === "cache" && (
+          <section className="activity__card">
+            <h2>Cache Metadata</h2>
+            <p>
+              Cache entry:{" "}
+              {cachedEntry ? (
+                <span>
+                  created {new Date(cachedEntry.createdAt).toLocaleTimeString()} • last accessed {" "}
+                  {new Date(cachedEntry.lastAccessed).toLocaleTimeString()}
+                </span>
+              ) : (
+                <span>no cached data available</span>
+              )}
+            </p>
+          </section>
+        )}
+      </div>
+    </AppScreen>
+  );
+};
+
+export default LabsPerformanceDetailActivity;

--- a/src/labs/performance/perfCache.ts
+++ b/src/labs/performance/perfCache.ts
@@ -1,0 +1,175 @@
+import { useSyncExternalStore } from "react";
+
+export type PerfCacheEntry = {
+  activityId: string;
+  label: string;
+  data: Uint8Array;
+  sizeMB: number;
+  createdAt: number;
+  lastAccessed: number;
+};
+
+type PerfCacheSnapshot = {
+  entries: PerfCacheEntry[];
+  totalMB: number;
+};
+
+type SummarySnapshot = {
+  entryCount: number;
+  totalMB: number;
+};
+
+class PerfCacheStore {
+  private entries = new Map<string, PerfCacheEntry>();
+
+  private listeners = new Set<() => void>();
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  private emit() {
+    this.listeners.forEach((listener) => listener());
+  }
+
+  write(entry: PerfCacheEntry) {
+    this.entries.set(entry.activityId, entry);
+    this.emit();
+  }
+
+  touch(activityId: string) {
+    const current = this.entries.get(activityId);
+    if (!current) {
+      return;
+    }
+
+    this.entries.set(activityId, {
+      ...current,
+      lastAccessed: Date.now(),
+    });
+    this.emit();
+  }
+
+  remove(activityId: string) {
+    if (this.entries.delete(activityId)) {
+      this.emit();
+    }
+  }
+
+  clear() {
+    if (this.entries.size === 0) {
+      return;
+    }
+
+    this.entries.clear();
+    this.emit();
+  }
+
+  evictTo(maxTotalMB: number) {
+    let total = this.computeTotalMB();
+    if (total <= maxTotalMB) {
+      return;
+    }
+
+    const ordered = Array.from(this.entries.values()).sort(
+      (a, b) => a.lastAccessed - b.lastAccessed,
+    );
+
+    for (const entry of ordered) {
+      if (total <= maxTotalMB) {
+        break;
+      }
+
+      this.entries.delete(entry.activityId);
+      total -= entry.sizeMB;
+    }
+
+    this.emit();
+  }
+
+  getEntry(activityId: string) {
+    return this.entries.get(activityId);
+  }
+
+  getSnapshot(): PerfCacheSnapshot {
+    const entries = Array.from(this.entries.values()).sort(
+      (a, b) => b.lastAccessed - a.lastAccessed,
+    );
+    return {
+      entries,
+      totalMB: this.computeTotalMB(),
+    };
+  }
+
+  getSummary(): SummarySnapshot {
+    return {
+      entryCount: this.entries.size,
+      totalMB: Number(this.computeTotalMB().toFixed(2)),
+    };
+  }
+
+  private computeTotalMB() {
+    let total = 0;
+    this.entries.forEach((entry) => {
+      total += entry.sizeMB;
+    });
+    return total;
+  }
+}
+
+const store = new PerfCacheStore();
+
+export const perfCacheStore = store;
+
+export const registerCacheEntry = (
+  activityId: string,
+  label: string,
+  data: Uint8Array,
+) => {
+  const sizeMB = data.byteLength / (1024 * 1024);
+  const timestamp = Date.now();
+  store.write({
+    activityId,
+    label,
+    data,
+    sizeMB,
+    createdAt: timestamp,
+    lastAccessed: timestamp,
+  });
+};
+
+export const touchCacheEntry = (activityId: string) => {
+  store.touch(activityId);
+};
+
+export const removeCacheEntry = (activityId: string) => {
+  store.remove(activityId);
+};
+
+export const clearCache = () => {
+  store.clear();
+};
+
+export const evictCacheTo = (maxTotalMB: number) => {
+  store.evictTo(maxTotalMB);
+};
+
+export const usePerfCacheEntry = (activityId: string) =>
+  useSyncExternalStore(store.subscribe, () => store.getEntry(activityId), () =>
+    store.getEntry(activityId),
+  );
+
+export const usePerfCacheEntries = () =>
+  useSyncExternalStore(store.subscribe, () => store.getSnapshot().entries, () =>
+    store.getSnapshot().entries,
+  );
+
+export const usePerfCacheSummary = () =>
+  useSyncExternalStore(store.subscribe, () => store.getSummary(), () =>
+    store.getSummary(),
+  );
+
+export const getCacheTotalMB = () => store.getSummary().totalMB;

--- a/src/lib/NFXStack.tsx
+++ b/src/lib/NFXStack.tsx
@@ -12,6 +12,7 @@ import { navFlagPlugin } from "../plugins/navFlagPlugin";
 
 // ActivityComponentType 제네릭이 사실상 불공변이어서 공용 레지스트리는 `any`로 둬야 한다.
 // 액티비티를 선언하는 쪽에서 params 타입은 유지되지만, 내부 저장소는 모든 형태를 받아야 한다.
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type ActivityRegistry = Record<string, ActivityComponentType<any>>;
 type RouteRegistry = Record<string, RouteLike<ActivityComponentType<any>>>;
 
@@ -23,6 +24,7 @@ export type StackRouteConfig<
   route?: RouteLike<TActivity>;
   initial?: boolean;
 };
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 type Props = {
   routes: ReadonlyArray<StackRouteConfig>;

--- a/src/plugins/navFlagPlugin.ts
+++ b/src/plugins/navFlagPlugin.ts
@@ -39,12 +39,13 @@ const sanitizeRecord = <T extends UnknownRecord | undefined>(params: T): T => {
     return params;
   }
 
-  if (!(NAV_FLAG_FIELD in params)) {
+  if (!Object.prototype.hasOwnProperty.call(params, NAV_FLAG_FIELD)) {
     return params;
   }
 
-  const { [NAV_FLAG_FIELD]: _ignored, ...rest } = params as NavFlagCarrier;
-  return rest as T;
+  const sanitized = { ...(params as NavFlagCarrier) };
+  delete sanitized[NAV_FLAG_FIELD];
+  return sanitized as T;
 };
 
 /**
@@ -67,7 +68,8 @@ const handleBeforePush: StackflowPluginPreEffectHook<PushActionParams> = ({ acti
 
   if (!navFlag) {
     // 플래그는 없지만 내부 키가 남아있다면, 호출부 params가 노출되지 않도록 제거합니다.
-    if ((actionParams.activityParams as UnknownRecord | undefined)?.hasOwnProperty?.(NAV_FLAG_FIELD)) {
+    const candidate = actionParams.activityParams as UnknownRecord | undefined;
+    if (candidate && Object.prototype.hasOwnProperty.call(candidate, NAV_FLAG_FIELD)) {
       actions.overrideActionParams({
         ...actionParams,
         activityParams: sanitizeRecord(actionParams.activityParams as UnknownRecord) as ActivityParamsShape,


### PR DESCRIPTION
## Summary
- add a labs performance hub that surfaces stack depth, configurable payload sizes, and cache controls for stress testing the navigation stack
- implement a detail activity that generates large payloads with for loops, persists them either locally or via the new performance cache store, and exposes cache metadata for analysis
- wire the new routes into the stack, update navigation/styles, and clean up lint issues in the nav flag plugin and stack registry typings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3909d1d108326a66af7eabe63187e